### PR TITLE
feat: fix resoultion and window mode

### DIFF
--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -59,8 +59,8 @@
 +AxisConfig=(AxisKeyName="ValveIndex_Right_Trackpad_X",AxisProperties=(DeadZone=0.000000,Sensitivity=1.000000,Exponent=1.000000,bInvert=False))
 +AxisConfig=(AxisKeyName="ValveIndex_Right_Trackpad_Y",AxisProperties=(DeadZone=0.000000,Sensitivity=1.000000,Exponent=1.000000,bInvert=False))
 +AxisConfig=(AxisKeyName="ValveIndex_Right_Trackpad_Force",AxisProperties=(DeadZone=0.000000,Sensitivity=1.000000,Exponent=1.000000,bInvert=False))
-bAltEnterTogglesFullscreen=True
-bF11TogglesFullscreen=True
+bAltEnterTogglesFullscreen=False
+bF11TogglesFullscreen=False
 bUseMouseForTouch=False
 bEnableMouseSmoothing=True
 bEnableFOVScaling=True

--- a/Source/CookYourWay/GameMode/CookYourWayGameMode.cpp
+++ b/Source/CookYourWay/GameMode/CookYourWayGameMode.cpp
@@ -4,6 +4,8 @@
 #include "GameMode/CookYourWayGameMode.h"
 #include <Kismet/GameplayStatics.h>
 #include <GameInstance/CookYourWayGameInstance.h>
+#include "GameFramework/GameUserSettings.h"
+#include "Engine/GameViewportClient.h"
 
 void ACookYourWayGameMode::InitGame(const FString& MapName, const FString& Option, FString& ErrorMessage)
 {
@@ -17,4 +19,13 @@ void ACookYourWayGameMode::InitGame(const FString& MapName, const FString& Optio
 void ACookYourWayGameMode::BeginPlay()
 {
 	Super::BeginPlay();
+
+	UGameUserSettings* Settings = GEngine->GetGameUserSettings();
+	if (Settings)
+	{
+		// 창모드, 해상도 고정
+		Settings->SetFullscreenMode(EWindowMode::Windowed);
+		Settings->SetScreenResolution(FIntPoint(1920, 1080));
+		Settings->ApplySettings(false);
+	}
 }


### PR DESCRIPTION
- 해상도 1920 x 1080으로 고정
- 창모드 고정
- Alt + Enter, F11 단축키를 이용해 전체 화면으로 전환하지 못하도록 처리